### PR TITLE
change what the action does when app is not given

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Client cert, required only for MTLS session'
     required: false
   app_jar:  
-    description: 'Name of the app to be deployed'
+    description: 'Path and name of the app to be deployed'
     required: false
 
 runs:


### PR DESCRIPTION
When app/path is not given as an input it looks for .jar file under ./build/libs and it will deploy the app that it finds there. 
If there are multiple .jar files under ./build/libs it will request the user to specify the app name as an input to the action.